### PR TITLE
Add 320kbps field to track data for enhanced audio quality

### DIFF
--- a/api/jioSaavn.ts
+++ b/api/jioSaavn.ts
@@ -171,7 +171,7 @@ export class JioSaavnAPI {
 			albumName: null,
 			artistArtworkUrl: null,
 			previewUrl: null,
-			320kbps: track?.more_info?.320kbps,
+			"320kbps": track?.more_info?.["320kbps"],
 		};
 
 		if (track?.perma_url) {

--- a/api/jioSaavn.ts
+++ b/api/jioSaavn.ts
@@ -171,7 +171,7 @@ export class JioSaavnAPI {
 			albumName: null,
 			artistArtworkUrl: null,
 			previewUrl: null,
-			"320kbps": track?.more_info?.["320kbps"],
+			"320kbps": track?.more_info?.["320kbps"], //Add 320kbps field to track data for enhanced audio quality
 		};
 
 		if (track?.perma_url) {

--- a/api/jioSaavn.ts
+++ b/api/jioSaavn.ts
@@ -171,6 +171,7 @@ export class JioSaavnAPI {
 			albumName: null,
 			artistArtworkUrl: null,
 			previewUrl: null,
+			320kbps: track?.more_info?.320kbps,
 		};
 
 		if (track?.perma_url) {


### PR DESCRIPTION
This PR adds the 320kbps field to the track data object.
The JioSaavn plugin for Lavalink relies on this property to determine high-quality audio availability. It seems this was unintentionally omitted earlier.

By including "320kbps": track?.more_info?.["320kbps"], this change ensures that the plugin can fetch and stream the highest possible audio quality (320kbps), which significantly improves the listening experience.